### PR TITLE
add binary.createServer(fn) to be more like http.createServer

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -8,15 +8,15 @@ function BinaryServer(options) {
   if (!(this instanceof BinaryServer)) return new BinaryServer(options);
 
   var self = this;
-  
+
   options = util.extend({
     host: '0.0.0.0',
     chunkSize: 40960
   }, options);
-  
+
   this.clients = {};
   this._clientCounter = 0;
-  
+
   this._server  = new ws.Server(options);
   this._server.on('connection', function(socket){
     var clientId = self._clientCounter;
@@ -42,3 +42,29 @@ BinaryServer.prototype.close = function(code, message){
 
 exports.BinaryClient = BinaryClient;
 exports.BinaryServer = BinaryServer;
+
+// Expose a method similar to http.createServer
+//
+// usage:
+//  var fs = require('fs');
+//  require('binaryjs').createServer(function(c) {
+//    fs.createReadStream('some.bin').pipe(c);
+//  });
+//
+exports.createServer = function(fn) {
+  var server;
+
+  return {
+    listen : function(port, opts) {
+      opts = opts || {};
+      opts.port = port;
+
+      var server = new BinaryServer({ port : port });
+      server.on('connection', function(conn) {
+        fn && fn(conn.createStream());
+      });
+
+      return server;
+    }
+  }
+};


### PR DESCRIPTION
here's how I intend on using this

```
var
  kinect = require('../../index').createStream('depth', null, 2),
  ecstatic = require('ecstatic')(__dirname + '/static');

require('http').createServer(ecstatic).listen(10000);

require('binaryjs').createServer(function(conn) {
  kinect.pipe(conn);
}).listen(10001),
```
