### PR TITLE
Use error events for malformed input

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -81,16 +81,16 @@ function BinaryClient(socket, options) {
       try {
           data = util.unpack(data);
       } catch (ex) {
-          return self.emit('error', 'Received unparsable message: ' + ex);
+          return self.emit('error', new Error('Received unparsable message: ' + ex));
       }
       if (!(data instanceof Array))
-          return self.emit('error', 'Received non-array message');
+          return self.emit('error', new Error('Received non-array message'));
       if (data.length != 3)
-          return self.emit('error', 'Received message with wrong part count: ' + data.length);
+          return self.emit('error', new Error('Received message with wrong part count: ' + data.length));
       if ('number' != typeof data[0])
-          return self.emit('error', 'Received message with non-number type: ' + data[0]);
+          return self.emit('error', new Error('Received message with non-number type: ' + data[0]));
       if ('number' != typeof data[2])
-          return self.emit('error', 'Received message with non-number streamId: ' + data[2]);
+          return self.emit('error', new Error('Received message with non-number streamId: ' + data[2]));
 
       switch(data[0]) {
         case 0:
@@ -109,7 +109,7 @@ function BinaryClient(socket, options) {
           if(binaryStream) {
             binaryStream._onData(payload);
           } else {
-            self.emit('error', 'Received `data` message for unknown stream: ' + streamId);
+            self.emit('error', new Error('Received `data` message for unknown stream: ' + streamId));
           }
           break;
         case 3:
@@ -118,7 +118,7 @@ function BinaryClient(socket, options) {
           if(binaryStream) {
             binaryStream._onPause();
           } else {
-            self.emit('error', 'Received `pause` message for unknown stream: ' + streamId);
+            self.emit('error', new Error('Received `pause` message for unknown stream: ' + streamId));
           }
           break;
         case 4:
@@ -127,7 +127,7 @@ function BinaryClient(socket, options) {
           if(binaryStream) {
             binaryStream._onResume();
           } else {
-            self.emit('error', 'Received `resume` message for unknown stream: ' + streamId);
+            self.emit('error', new Error('Received `resume` message for unknown stream: ' + streamId));
           }
           break;
         case 5:
@@ -136,7 +136,7 @@ function BinaryClient(socket, options) {
           if(binaryStream) {
             binaryStream._onEnd();
           } else {
-            self.emit('error', 'Received `end` message for unknown stream: ' + streamId);
+            self.emit('error', new Error('Received `end` message for unknown stream: ' + streamId));
           }
           break;
         case 6:
@@ -145,11 +145,11 @@ function BinaryClient(socket, options) {
           if(binaryStream) {
             binaryStream._onClose();
           } else {
-            self.emit('error', 'Received `close` message for unknown stream: ' + streamId);
+            self.emit('error', new Error('Received `close` message for unknown stream: ' + streamId));
           }
           break;
         default:
-          self.emit('error', 'Unrecognized message type received: ' + data[0]);
+          self.emit('error', new Error('Unrecognized message type received: ' + data[0]));
       }
     });
   });


### PR DESCRIPTION
The context here is that I've written a node server which uses BinaryJS, and I don't want users to be able to remotely kill the server by sending bogus data, at least not easily.
