### PR TITLE
Fixed bug using BinaryJS between two servers.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ var BinaryStream = require('./stream').BinaryStream;
 // end node
 
 function BinaryClient(socket, options) {
-  if (!(this instanceof BinaryClient)) return new BinaryClient(options);
+  if (!(this instanceof BinaryClient)) return new BinaryClient(socket, options);
   
   EventEmitter.call(this);
   


### PR DESCRIPTION
Adding the missing first parameter used by BinaryClient for new instance
creation.
