### PR TITLE
Fix for crit bug when closing pipe stream

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -54,7 +54,9 @@ function BinaryClient(socket, options) {
   this._socket.addEventListener('close', function(code, message){
     var ids = Object.keys(self.streams);
     for (var i = 0, ii = ids.length; i < ii; i++) {
-      self.streams[ids[i]]._onClose();
+      if(!!self.streams[ids[i]]) {
+        self.streams[ids[i]]._onClose();
+      }
     }
     self.emit('close', code, message);
   });


### PR DESCRIPTION
When we use pipe method of BinaryStream and close connected browser page - server got crit error:

```js
TypeError: Cannot call method '_onClose' of undefined
  at WebSocket.<anonymous> (/srv/http/socialstream/server/node_modules/binaryjs/lib/client.js:59:28)
  at WebSocket.EventEmitter.emit (events.js:117:20)
  at WebSocket.cleanupWebsocketResources (/srv/http/socialstream/server/node_modules/binaryjs/node_modules/streamws/lib/WebSocket.js:619:23)
  at Socket.EventEmitter.emit (events.js:117:20)
  at _stream_readable.js:920:16
  at process._tickCallback (node.js:415:13)
```

It is fast fix for this. It easy to found reason by following callstack - when stream is closed it automatically close his pipe destination stream and removed it from self.streams array.